### PR TITLE
Fix fast view removal

### DIFF
--- a/lib/TransitionGroup.js
+++ b/lib/TransitionGroup.js
@@ -168,14 +168,14 @@ class TransitionGroup extends Component {
       // This entered again before it fully left. Add it again.
       this.performEnter(key);
     } else {
-      const newChildren = {
-        ...this.state.children,
-      };
+      this.setState(prevState => {
+        const newChildren = {
+          ...prevState.children,
+        };
+  
+        delete newChildren[key];
 
-      delete newChildren[key];
-
-      this.setState({
-        children: newChildren,
+        return { children: newChildren };
       });
     }
   }


### PR DESCRIPTION
This fixes a problem where `children` were not being removed if `handleDoneLeaving` was called too fast. `setState` is "delayed" by default, meaning react will batch calls and apply the visual changes only once. 

The current version is using `this.state.children` inside `handleDoneLeaving` which means that if the method is called again before the new state has been applied, it will still contain the item removed in the previous call (or calls).