### PR TITLE
Remove deprecated componentWillMount; remove unused declaration

### DIFF
--- a/lib/FadeInOutTransition.js
+++ b/lib/FadeInOutTransition.js
@@ -4,7 +4,6 @@ import {
   Animated,
   Easing,
   StyleSheet,
-  View,
   ViewPropTypes,
 } from 'react-native';
 

--- a/lib/TransitionGroup.js
+++ b/lib/TransitionGroup.js
@@ -17,13 +17,11 @@ class TransitionGroup extends Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.currentlyTransitioningKeys = {};
     this.keysToEnter = [];
     this.keysToLeave = [];
-  }
 
-  componentDidMount() {
     const initialChildMapping = this.state.children;
 
     Object.keys(initialChildMapping).forEach((key) => {


### PR DESCRIPTION
`componentWillMount` is deprecated, was straightforward to remove. 

There is also deprecated `componentWillReceiveProps` in the library. It contains some obscure logic, so I left it untouched.